### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 ---
 
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dzervas/magicentry/security/code-scanning/2](https://github.com/dzervas/magicentry/security/code-scanning/2)

To fix the issue, we will explicitly set the permissions for the workflow at the root level to restrict them to the minimum required. Since the workflow involves running tests and does not perform any actions requiring write permissions, we will apply `contents: read` as the only required permission. This ensures that the workflow operates securely and adheres to the principle of least privilege.

The changes will be made at the root of the workflow file, `.github/workflows/test.yaml`, before the `on:` directive.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
