### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yaml
 
   bump:


### PR DESCRIPTION
Potential fix for [https://github.com/dzervas/magicentry/security/code-scanning/1](https://github.com/dzervas/magicentry/security/code-scanning/1)

To fix the problem, we should add a `permissions` key to the `test` job so that it limits the permissions of the `GITHUB_TOKEN`. Since this job likely only needs to read contents (if it needs anything at all), we can set `permissions: contents: read` as the minimal starting point. This change should be made in `.github/workflows/release.yaml`, by inserting the `permissions` block directly under the `test:` job definition, before or after the `uses:` key. No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
