### PR TITLE
Fix SAML key PEM header parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -196,12 +196,14 @@ impl ConfigFile {
 	/// filepath
 	pub fn get_saml_key(&self) -> Result<String, std::io::Error> {
 		let data = std::fs::read_to_string(&self.saml_key_pem_path)?;
-		Ok(data
-			.lines()
-			.filter(|line| !line.contains("BEGIN CERTIFICATE") && !line.contains("END CERTIFICATE"))
-			.collect::<String>()
-			.replace("\n", ""))
-	}
+                Ok(data
+                        .lines()
+                        .filter(|line| {
+                                !line.contains("BEGIN PRIVATE KEY") && !line.contains("END PRIVATE KEY")
+                        })
+                        .collect::<String>()
+                        .replace("\n", ""))
+        }
 }
 
 /// Basic key-value store database schema for some minor config values,

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -1,0 +1,15 @@
+use crate::config::ConfigFile;
+use uuid::Uuid;
+
+#[test]
+fn get_saml_key_strips_pem_headers() {
+    let pem = "-----BEGIN PRIVATE KEY-----\nABCDEF\n-----END PRIVATE KEY-----\n";
+    let path = std::env::temp_dir().join(format!("testkey-{}.pem", Uuid::new_v4()));
+    std::fs::write(&path, pem).expect("write pem");
+
+    let mut config = ConfigFile::default();
+    config.saml_key_pem_path = path.to_string_lossy().into_owned();
+
+    let key = config.get_saml_key().expect("read key");
+    assert_eq!(key, "ABCDEF");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
 pub mod flow_scoped;
+pub mod config;


### PR DESCRIPTION
## Summary
- fix SAML private key reader to strip PEM header/footer correctly
- test SAML key parsing to ensure headers are removed

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a45baff86883259c09b0500609f36c