### PR TITLE
feat(kube): manage OIDC secrets for ingress

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "concurrently 'yarn:start-web' 'yarn:start-e2e'",
     "build": "webpack build --mode production && tailwindcss --input static/css/main.css --output static/main.build.css --minify",
-    "test": "cargo test --color always --features kube && yarn start-e2e & export SRVPID=$!; yarn test-e2e; export RESULT=$?; kill $SRVPID; exit $RESULT",
-    "test-e2e": "until curl -sSf http://localhost:8080 >/dev/null; do sleep 1; done; hurl --test --jobs 1 ./hurl",
+    "test": "cargo test --color always --features kube && bash -c 'yarn start-e2e & export SRVPID=$!; yarn test-e2e; export RESULT=$?; kill $SRVPID; exit $RESULT'",
+    "test-e2e": "bash -c 'until curl -sSf http://localhost:8080 >/dev/null; do sleep 1; done; hurl --test --jobs 1 ./hurl'",
     "test-server": "cargo test --color always --features e2e-test",
     "start-web": "concurrently --name tailwind,webpack 'yarn:tailwind-dev' 'yarn:webpack-dev'",
     "tailwind-dev": "tailwindcss --input static/css/main.css --output static/main.build.css --watch",

--- a/src/config_kube.rs
+++ b/src/config_kube.rs
@@ -104,73 +104,73 @@ impl IngressConfig {
 			return Err(AppErrorKind::IngressHasNoHost.into());
 		};
 
-        let oidc = if let Some(secret_name) = &self.oidc_target_secret {
-                let namespace = ingress.metadata.namespace.as_deref().unwrap_or("default");
-                let client = Client::try_default().await?;
-                let secrets: Api<Secret> = Api::namespaced(client, namespace);
-        
-                let existing = secrets.get_opt(secret_name).await?;
-                let mut client_id = existing
-                        .as_ref()
-                        .and_then(|s| s.data.as_ref())
-                        .and_then(|d| d.get("clientID"))
-                        .and_then(|b| String::from_utf8(b.0.clone()).ok())
-                        .unwrap_or_else(random_string);
-                let mut client_secret = existing
-                        .as_ref()
-                        .and_then(|s| s.data.as_ref())
-                        .and_then(|d| d.get("clientSecret"))
-                        .and_then(|b| String::from_utf8(b.0.clone()).ok())
-                        .unwrap_or_else(random_string);
-        
-                let mut data = BTreeMap::new();
-                data.insert("clientID".to_string(), ByteString(client_id.clone().into_bytes()));
-                data.insert("clientSecret".to_string(), ByteString(client_secret.clone().into_bytes()));
-        
-                let annotations = BTreeMap::from([(format!("{ANNOTATION_PREFIX}part-of"), self.name.clone())]);
-        
-                let secret = Secret {
-                        metadata: ObjectMeta {
-                                name: Some(secret_name.clone()),
-                                annotations: Some(annotations),
-                                ..ObjectMeta::default()
-                        },
-                        data: Some(data),
-                        type_: Some("Opaque".to_string()),
-                        ..Secret::default()
-                };
-        
-                let pp = PatchParams::apply("magicentry").force();
-                let patch = Patch::Apply(&secret);
-                secrets.patch(secret_name, &pp, &patch).await?;
-        
-                Some(ServiceOIDC {
-                        client_id,
-                        client_secret,
-                        redirect_urls: self.oidc_redirect_urls.clone(),
-                })
-        } else {
-                None
-        };
+		let oidc = if let Some(secret_name) = &self.oidc_target_secret {
+			let namespace = ingress.metadata.namespace.as_deref().unwrap_or("default");
+			let client = Client::try_default().await?;
+			let secrets: Api<Secret> = Api::namespaced(client, namespace);
 
-        let service = Service {
-        			name: self.name.clone(),
-        			// Iterate over spec.rules[].host and see if spec.tls[].hosts contains the host
-        			url: service_url,
-        			realms: self.realms.clone(),
-        			auth_url: if self.auth_url {
-        				Some(ServiceAuthUrl {
-        					origins: urls
-        						.iter()
-        						.map(|url| url.to_string())
-        						.collect(),
-        				})
-        			} else {
-        				None
-        			},
-        			oidc,
-        			saml: None,
-        		};
+			let existing = secrets.get_opt(secret_name).await?;
+			let client_id = existing
+				.as_ref()
+				.and_then(|s| s.data.as_ref())
+				.and_then(|d| d.get("clientID"))
+				.and_then(|b| String::from_utf8(b.0.clone()).ok())
+				.unwrap_or_else(random_string);
+			let client_secret = existing
+				.as_ref()
+				.and_then(|s| s.data.as_ref())
+				.and_then(|d| d.get("clientSecret"))
+				.and_then(|b| String::from_utf8(b.0.clone()).ok())
+				.unwrap_or_else(random_string);
+
+			let mut data = BTreeMap::new();
+			data.insert("clientID".to_string(), ByteString(client_id.clone().into_bytes()));
+			data.insert("clientSecret".to_string(), ByteString(client_secret.clone().into_bytes()));
+
+			let annotations = BTreeMap::from([("app.kubernetes.io/part-of".to_string(), self.name.clone())]);
+
+			let secret = Secret {
+				metadata: ObjectMeta {
+					name: Some(secret_name.clone()),
+					annotations: Some(annotations),
+					..ObjectMeta::default()
+				},
+				data: Some(data),
+				type_: Some("Opaque".to_string()),
+				..Secret::default()
+			};
+
+			let pp = PatchParams::apply("magicentry").force();
+			let patch = Patch::Apply(&secret);
+			secrets.patch(secret_name, &pp, &patch).await?;
+
+			Some(ServiceOIDC {
+				client_id,
+				client_secret,
+				redirect_urls: self.oidc_redirect_urls.clone(),
+			})
+		} else {
+			None
+		};
+
+		let service = Service {
+			name: self.name.clone(),
+			// Iterate over spec.rules[].host and see if spec.tls[].hosts contains the host
+			url: service_url,
+			realms: self.realms.clone(),
+			auth_url: if self.auth_url {
+				Some(ServiceAuthUrl {
+					origins: urls
+						.iter()
+						.map(|url| url.to_string())
+						.collect(),
+				})
+			} else {
+				None
+			},
+			oidc,
+			saml: None,
+		};
 
 		// Take the write lock at the last possible moment and drop it
 		// as soon as possible to avoid blocking other threads/contexts
@@ -212,40 +212,40 @@ impl From<&BTreeMap<String, String>> for IngressConfig {
 				.get("name")
 				.map(|v| v.to_string())
 				.unwrap_or_default(),
-                        auth_url: filtered_map
-                                .get("auth_url")
-                                .map(|v| *v == "true")
-                                .unwrap_or_default(),
-                        realms: filtered_map
-                                .get("realms")
-                                .map(|v| v.split(",").map(|v| v.to_string()).collect())
-                                .unwrap_or_default(),
-                        oidc_target_secret: filtered_map
-                                .get("oidc_target_secret")
-                                .map(|v| v.to_string()),
-                        oidc_redirect_urls: filtered_map
-                                .get("oidc_redirect_urls")
-                                .map(|v| {
-                                        v.split(",")
-                                                .filter_map(|u| url::Url::parse(u).ok())
-                                                .collect()
-                                })
-                                .unwrap_or_default(),
-                        saml_entity_id: filtered_map
-                                .get("saml_entity_id")
-                                .map(|v| v.to_string()),
-                        saml_redirect_urls: filtered_map
-                                .get("saml_redirect_urls")
-                                .map(|v| {
-                                        v.split(",")
-                                                .filter_map(|u| url::Url::parse(u).ok())
-                                                .collect()
-                                })
-                                .unwrap_or_default(),
-                        manage_ingress_nginx: filtered_map
-                                .get("manage_ingress_nginx")
-                                .map(|v| *v == "true")
-                                .unwrap_or_default(),
+			auth_url: filtered_map
+				.get("auth_url")
+				.map(|v| *v == "true")
+				.unwrap_or_default(),
+			realms: filtered_map
+				.get("realms")
+				.map(|v| v.split(",").map(|v| v.to_string()).collect())
+				.unwrap_or_default(),
+			oidc_target_secret: filtered_map
+				.get("oidc_target_secret")
+				.map(|v| v.to_string()),
+			oidc_redirect_urls: filtered_map
+				.get("oidc_redirect_urls")
+				.map(|v| {
+					v.split(",")
+						.filter_map(|u| url::Url::parse(u).ok())
+						.collect()
+				})
+				.unwrap_or_default(),
+			saml_entity_id: filtered_map
+				.get("saml_entity_id")
+				.map(|v| v.to_string()),
+			saml_redirect_urls: filtered_map
+				.get("saml_redirect_urls")
+				.map(|v| {
+					v.split(",")
+						.filter_map(|u| url::Url::parse(u).ok())
+						.collect()
+				})
+				.unwrap_or_default(),
+			manage_ingress_nginx: filtered_map
+				.get("manage_ingress_nginx")
+				.map(|v| *v == "true")
+				.unwrap_or_default(),
 		}
 	}
 }

--- a/src/config_kube.rs
+++ b/src/config_kube.rs
@@ -10,14 +10,18 @@
 use std::collections::{BTreeMap, HashMap};
 
 use futures::TryStreamExt;
+use k8s_openapi::api::core::v1::Secret;
 use k8s_openapi::api::networking::v1::Ingress;
+use k8s_openapi::ByteString;
 use kube::runtime::watcher;
 use kube::runtime::watcher::Event;
-use kube::{Api, Client};
+use kube::{api::{Patch, PatchParams}, Api, Client};
+use kube::core::ObjectMeta;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppErrorKind, Result};
-use crate::service::{Service, ServiceAuthUrl};
+use crate::service::{Service, ServiceAuthUrl, ServiceOIDC};
+use crate::utils::random_string;
 use crate::CONFIG;
 
 /// The prefix for all magicentry-related annotations
@@ -100,27 +104,73 @@ impl IngressConfig {
 			return Err(AppErrorKind::IngressHasNoHost.into());
 		};
 
-		let service = Service {
-			name: self.name.clone(),
-			// Iterate over spec.rules[].host and see if spec.tls[].hosts contains the host
-			url: service_url,
-			realms: self.realms.clone(),
-			auth_url: if self.auth_url {
-				Some(ServiceAuthUrl {
-					origins: urls
-						.iter()
-						.map(|url| url.to_string())
-						.collect(),
-				})
-			} else {
-				None
-			},
-			oidc: None,
-			// oidc: if let Some(oidc_target_secret) = self.oidc_target_secret {
-			// 	Some
-			// } else { None }
-			saml: None,
-		};
+        let oidc = if let Some(secret_name) = &self.oidc_target_secret {
+                let namespace = ingress.metadata.namespace.as_deref().unwrap_or("default");
+                let client = Client::try_default().await?;
+                let secrets: Api<Secret> = Api::namespaced(client, namespace);
+        
+                let existing = secrets.get_opt(secret_name).await?;
+                let mut client_id = existing
+                        .as_ref()
+                        .and_then(|s| s.data.as_ref())
+                        .and_then(|d| d.get("clientID"))
+                        .and_then(|b| String::from_utf8(b.0.clone()).ok())
+                        .unwrap_or_else(random_string);
+                let mut client_secret = existing
+                        .as_ref()
+                        .and_then(|s| s.data.as_ref())
+                        .and_then(|d| d.get("clientSecret"))
+                        .and_then(|b| String::from_utf8(b.0.clone()).ok())
+                        .unwrap_or_else(random_string);
+        
+                let mut data = BTreeMap::new();
+                data.insert("clientID".to_string(), ByteString(client_id.clone().into_bytes()));
+                data.insert("clientSecret".to_string(), ByteString(client_secret.clone().into_bytes()));
+        
+                let annotations = BTreeMap::from([(format!("{ANNOTATION_PREFIX}part-of"), self.name.clone())]);
+        
+                let secret = Secret {
+                        metadata: ObjectMeta {
+                                name: Some(secret_name.clone()),
+                                annotations: Some(annotations),
+                                ..ObjectMeta::default()
+                        },
+                        data: Some(data),
+                        type_: Some("Opaque".to_string()),
+                        ..Secret::default()
+                };
+        
+                let pp = PatchParams::apply("magicentry").force();
+                let patch = Patch::Apply(&secret);
+                secrets.patch(secret_name, &pp, &patch).await?;
+        
+                Some(ServiceOIDC {
+                        client_id,
+                        client_secret,
+                        redirect_urls: self.oidc_redirect_urls.clone(),
+                })
+        } else {
+                None
+        };
+
+        let service = Service {
+        			name: self.name.clone(),
+        			// Iterate over spec.rules[].host and see if spec.tls[].hosts contains the host
+        			url: service_url,
+        			realms: self.realms.clone(),
+        			auth_url: if self.auth_url {
+        				Some(ServiceAuthUrl {
+        					origins: urls
+        						.iter()
+        						.map(|url| url.to_string())
+        						.collect(),
+        				})
+        			} else {
+        				None
+        			},
+        			oidc,
+        			saml: None,
+        		};
 
 		// Take the write lock at the last possible moment and drop it
 		// as soon as possible to avoid blocking other threads/contexts
@@ -162,18 +212,40 @@ impl From<&BTreeMap<String, String>> for IngressConfig {
 				.get("name")
 				.map(|v| v.to_string())
 				.unwrap_or_default(),
-			auth_url: filtered_map
-				.get("auth_url")
-				.map(|v| *v == "true")
-				.unwrap_or_default(),
-			realms: filtered_map
-				.get("realms")
-				.map(|v| v.split(",").map(|v| v.to_string()).collect())
-				.unwrap_or_default(),
-			manage_ingress_nginx: filtered_map
-				.get("manage_ingress_nginx")
-				.map(|v| *v == "true")
-				.unwrap_or_default(),
+                        auth_url: filtered_map
+                                .get("auth_url")
+                                .map(|v| *v == "true")
+                                .unwrap_or_default(),
+                        realms: filtered_map
+                                .get("realms")
+                                .map(|v| v.split(",").map(|v| v.to_string()).collect())
+                                .unwrap_or_default(),
+                        oidc_target_secret: filtered_map
+                                .get("oidc_target_secret")
+                                .map(|v| v.to_string()),
+                        oidc_redirect_urls: filtered_map
+                                .get("oidc_redirect_urls")
+                                .map(|v| {
+                                        v.split(",")
+                                                .filter_map(|u| url::Url::parse(u).ok())
+                                                .collect()
+                                })
+                                .unwrap_or_default(),
+                        saml_entity_id: filtered_map
+                                .get("saml_entity_id")
+                                .map(|v| v.to_string()),
+                        saml_redirect_urls: filtered_map
+                                .get("saml_redirect_urls")
+                                .map(|v| {
+                                        v.split(",")
+                                                .filter_map(|u| url::Url::parse(u).ok())
+                                                .collect()
+                                })
+                                .unwrap_or_default(),
+                        manage_ingress_nginx: filtered_map
+                                .get("manage_ingress_nginx")
+                                .map(|v| *v == "true")
+                                .unwrap_or_default(),
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- generate and reconcile OIDC client credentials from ingress annotations
- store credentials in annotated Kubernetes secrets

## Testing
- `cargo test --features kube` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68acb29ba02c832588ec1c658dbe5135