### PR TITLE
feat(api): add api key management

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -17,6 +17,9 @@ link_duration: 1h
 # How long will a global session be valid for
 session_duration: 1mon
 
+# Maximum allowed API key duration (0 disables expiration limit)
+api_key_max_expiration: 365d
+
 # How often to run expired secrets cleanup
 secrets_cleanup_interval: 24h
 

--- a/hurl/api_key.hurl
+++ b/hurl/api_key.hurl
@@ -28,11 +28,10 @@ service: example
 expiration: 60
 HTTP 200
 [Captures]
-created_key: xpath "//code[@id='api-key']/text()"
+created_key: xpath "string(//code[@id='api-key'])"
 
 # Use created key
 GET http://localhost:8080/auth-url/status
-[Headers]
 X-Original-URL: http://localhost:8081/
 X-Api-Key: {{created_key}}
 HTTP 200
@@ -45,18 +44,16 @@ session_id: {{session}}
 key: {{created_key}}
 HTTP 200
 [Captures]
-rotated_key: xpath "//code[@id='api-key']/text()"
+rotated_key: xpath "string(//code[@id='api-key'])"
 
 # Old key should fail
 GET http://localhost:8080/auth-url/status
-[Headers]
 X-Original-URL: http://localhost:8081/
 X-Api-Key: {{created_key}}
 HTTP 401
 
 # New key should succeed
 GET http://localhost:8080/auth-url/status
-[Headers]
 X-Original-URL: http://localhost:8081/
 X-Api-Key: {{rotated_key}}
 HTTP 200
@@ -72,7 +69,6 @@ Location: /
 
 # Deleted key should fail
 GET http://localhost:8080/auth-url/status
-[Headers]
 X-Original-URL: http://localhost:8081/
 X-Api-Key: {{rotated_key}}
 HTTP 401

--- a/hurl/api_key.hurl
+++ b/hurl/api_key.hurl
@@ -38,11 +38,11 @@ X-Api-Key: {{created_key}}
 HTTP 200
 
 # Rotate key
-POST http://localhost:8080/api_key/{{created_key}}/rotate
+POST http://localhost:8080/api_key/rotate
 [Cookies]
 session_id: {{session}}
 [Form]
-service: example
+key: {{created_key}}
 HTTP 200
 [Captures]
 rotated_key: xpath "//code[@id='api-key']/text()"
@@ -62,9 +62,11 @@ X-Api-Key: {{rotated_key}}
 HTTP 200
 
 # Delete new key
-POST http://localhost:8080/api_key/{{rotated_key}}/delete
+POST http://localhost:8080/api_key/delete
 [Cookies]
 session_id: {{session}}
+[Form]
+key: {{rotated_key}}
 HTTP 302
 Location: /
 

--- a/hurl/api_key.hurl
+++ b/hurl/api_key.hurl
@@ -1,0 +1,83 @@
+# Login and create an API key
+GET http://localhost:8080/login
+HTTP 200
+[Asserts]
+xpath "//form[@method='post']" count == 1
+
+POST http://localhost:8080/login
+[Form]
+email: valid@example.com
+HTTP 200
+
+GET http://localhost:8081/.link.txt
+HTTP 200
+[Captures]
+link: body
+
+GET {{link}}
+HTTP 302
+Location: /
+[Captures]
+session: cookie "session_id"
+
+POST http://localhost:8080/api_key
+[Cookies]
+session_id: {{session}}
+[Form]
+service: example
+expiration: 60
+HTTP 200
+[Captures]
+created_key: xpath "//code[@id='api-key']/text()"
+
+# Use created key
+GET http://localhost:8080/auth-url/status
+[Headers]
+X-Original-URL: http://localhost:8081/
+X-Api-Key: {{created_key}}
+HTTP 200
+
+# Rotate key
+POST http://localhost:8080/api_key/{{created_key}}/rotate
+[Cookies]
+session_id: {{session}}
+[Form]
+service: example
+HTTP 200
+[Captures]
+rotated_key: xpath "//code[@id='api-key']/text()"
+
+# Old key should fail
+GET http://localhost:8080/auth-url/status
+[Headers]
+X-Original-URL: http://localhost:8081/
+X-Api-Key: {{created_key}}
+HTTP 401
+
+# New key should succeed
+GET http://localhost:8080/auth-url/status
+[Headers]
+X-Original-URL: http://localhost:8081/
+X-Api-Key: {{rotated_key}}
+HTTP 200
+
+# Delete new key
+POST http://localhost:8080/api_key/{{rotated_key}}/delete
+[Cookies]
+session_id: {{session}}
+HTTP 302
+Location: /
+
+# Deleted key should fail
+GET http://localhost:8080/auth-url/status
+[Headers]
+X-Original-URL: http://localhost:8081/
+X-Api-Key: {{rotated_key}}
+HTTP 401
+
+GET http://localhost:8080/
+[Cookies]
+session_id: {{session}}
+HTTP 200
+[Asserts]
+body contains "API Keys"

--- a/src/auth_url/handle_status.rs
+++ b/src/auth_url/handle_status.rs
@@ -3,8 +3,7 @@ use actix_web::{get, web, HttpResponse};
 use log::info;
 
 use crate::error::Response;
-use crate::secret::ProxySessionSecret;
-use crate::secret::ProxyCodeSecret;
+use crate::secret::{ApiKeySecret, ProxyCodeSecret, ProxySessionSecret};
 use crate::{CONFIG, PROXY_SESSION_COOKIE};
 
 /// This endpoint is used to check weather a user is logged in from a proxy
@@ -23,23 +22,47 @@ async fn status(
 	db: web::Data<crate::Database>,
 	proxy_code_opt: Option<ProxyCodeSecret>,
 	proxy_session_opt: Option<ProxySessionSecret>,
+	api_key_opt: Option<ApiKeySecret>,
 ) -> Response {
 	let mut response_builder = HttpResponse::Ok();
 	let mut response = response_builder.content_type("text/plain");
+
+	if let Some(api_key) = api_key_opt {
+		let config = CONFIG.read().await;
+		return Ok(response
+			.insert_header((
+				config.auth_url_email_header.as_str(),
+				api_key.user().email.clone(),
+			))
+			.insert_header((
+				config.auth_url_user_header.as_str(),
+				api_key.user().username.clone(),
+			))
+			.insert_header((
+				config.auth_url_name_header.as_str(),
+				api_key.user().name.clone(),
+			))
+			.insert_header((
+				config.auth_url_realms_header.as_str(),
+				api_key.user().realms.join(","),
+			))
+			.finish());
+	}
 
 	let proxy_session = if let Some(proxy_session) = proxy_session_opt {
 		proxy_session
 	} else if let Some(proxy_code) = proxy_code_opt {
 		info!("Proxied login for {}", &proxy_code.user().email);
-		let proxy_session = proxy_code
-			.exchange_sibling(&db)
-			.await?;
+		let proxy_session = proxy_code.exchange_sibling(&db).await?;
 
 		response = response.cookie(
-			Cookie::build(PROXY_SESSION_COOKIE, proxy_session.code().to_str_that_i_wont_print())
-				.path("/")
-				.http_only(true)
-				.finish(),
+			Cookie::build(
+				PROXY_SESSION_COOKIE,
+				proxy_session.code().to_str_that_i_wont_print(),
+			)
+			.path("/")
+			.http_only(true)
+			.finish(),
 		);
 
 		proxy_session
@@ -47,9 +70,7 @@ async fn status(
 		let mut remove_cookie = Cookie::new(PROXY_SESSION_COOKIE, "");
 		remove_cookie.make_removal();
 
-		return Ok(HttpResponse::Unauthorized()
-			.cookie(remove_cookie)
-			.finish());
+		return Ok(HttpResponse::Unauthorized().cookie(remove_cookie).finish());
 	};
 
 	let config = CONFIG.read().await;

--- a/src/handle_api_key.rs
+++ b/src/handle_api_key.rs
@@ -1,0 +1,102 @@
+use std::collections::BTreeMap;
+
+use actix_web::http::header::ContentType;
+use actix_web::{post, web, HttpResponse};
+use chrono::{Duration, Utc};
+use serde::Deserialize;
+
+use crate::database::Database;
+use crate::error::{AppErrorKind, Response};
+use crate::secret::{ApiKeySecret, BrowserSessionSecret};
+use crate::utils::get_partial;
+
+#[derive(Deserialize)]
+struct CreateForm {
+	service: String,
+	/// expiration in seconds
+	expiration: Option<i64>,
+}
+
+#[post("/api_key")]
+async fn create(
+	browser_session: BrowserSessionSecret,
+	form: web::Form<CreateForm>,
+	db: web::Data<Database>,
+) -> Response {
+	let duration = form
+		.expiration
+		.and_then(Duration::try_seconds)
+		.unwrap_or_else(|| chrono::Duration::seconds(0));
+	let key = ApiKeySecret::new_with_expiration(
+		browser_session.user().clone(),
+		form.service.clone(),
+		duration,
+		db.get_ref(),
+	)
+	.await?;
+	let mut data = BTreeMap::new();
+	data.insert("key", key.code().to_str_that_i_wont_print().to_string());
+	data.insert("id", key.code().to_str_that_i_wont_print().to_string());
+	let page = get_partial::<()>("api_key", data, None)?;
+	Ok(HttpResponse::Ok()
+		.content_type(ContentType::html())
+		.body(page))
+}
+
+#[derive(Deserialize)]
+struct IdPath {
+	id: String,
+}
+
+#[post("/api_key/{id}/delete")]
+async fn delete(
+	browser_session: BrowserSessionSecret,
+	path: web::Path<IdPath>,
+	db: web::Data<Database>,
+) -> Response {
+	let key = ApiKeySecret::try_from_string(path.id.clone(), db.get_ref()).await?;
+	if key.user() != browser_session.user() {
+		return Err(AppErrorKind::Unauthorized.into());
+	}
+	key.delete(db.get_ref()).await?;
+	Ok(HttpResponse::Found()
+		.append_header(("Location", "/"))
+		.finish())
+}
+
+#[post("/api_key/{id}/rotate")]
+async fn rotate(
+	browser_session: BrowserSessionSecret,
+	path: web::Path<IdPath>,
+	form: web::Form<CreateForm>,
+	db: web::Data<Database>,
+) -> Response {
+	let old = ApiKeySecret::try_from_string(path.id.clone(), db.get_ref()).await?;
+	if old.user() != browser_session.user() {
+		return Err(AppErrorKind::Unauthorized.into());
+	}
+	let remaining = if old.expires_at() == chrono::NaiveDateTime::MAX {
+		chrono::Duration::seconds(0)
+	} else {
+		old.expires_at() - Utc::now().naive_utc()
+	};
+	let new_key = ApiKeySecret::new_with_expiration(
+		browser_session.user().clone(),
+		form.service.clone(),
+		remaining,
+		db.get_ref(),
+	)
+	.await?;
+	old.delete(db.get_ref()).await?;
+	let mut data = BTreeMap::new();
+	data.insert("key", new_key.code().to_str_that_i_wont_print().to_string());
+	data.insert("id", new_key.code().to_str_that_i_wont_print().to_string());
+	let page = get_partial::<()>("api_key", data, None)?;
+	Ok(HttpResponse::Ok()
+		.content_type(ContentType::html())
+		.body(page))
+}
+
+pub fn init(cfg: &mut actix_web::web::ServiceConfig) {
+	cfg.service(create).service(delete).service(rotate);
+}

--- a/src/handle_api_key.rs
+++ b/src/handle_api_key.rs
@@ -2,11 +2,11 @@ use std::collections::BTreeMap;
 
 use actix_web::http::header::ContentType;
 use actix_web::{post, web, HttpResponse};
-use chrono::{Duration, Utc};
+use chrono::Duration;
 use serde::Deserialize;
 
 use crate::database::Database;
-use crate::error::{AppErrorKind, Response};
+use crate::error::Response;
 use crate::secret::{ApiKeySecret, BrowserSessionSecret};
 use crate::utils::get_partial;
 
@@ -36,7 +36,6 @@ async fn create(
 	.await?;
 	let mut data = BTreeMap::new();
 	data.insert("key", key.code().to_str_that_i_wont_print().to_string());
-	data.insert("id", key.code().to_str_that_i_wont_print().to_string());
 	let page = get_partial::<()>("api_key", data, None)?;
 	Ok(HttpResponse::Ok()
 		.content_type(ContentType::html())
@@ -44,53 +43,33 @@ async fn create(
 }
 
 #[derive(Deserialize)]
-struct IdPath {
-	id: String,
+struct KeyForm {
+	key: String,
 }
 
-#[post("/api_key/{id}/delete")]
+#[post("/api_key/delete")]
 async fn delete(
 	browser_session: BrowserSessionSecret,
-	path: web::Path<IdPath>,
+	form: web::Form<KeyForm>,
 	db: web::Data<Database>,
 ) -> Response {
-	let key = ApiKeySecret::try_from_string(path.id.clone(), db.get_ref()).await?;
-	if key.user() != browser_session.user() {
-		return Err(AppErrorKind::Unauthorized.into());
-	}
-	key.delete(db.get_ref()).await?;
+	ApiKeySecret::delete_with_user(form.key.clone(), browser_session.user(), db.get_ref()).await?;
 	Ok(HttpResponse::Found()
 		.append_header(("Location", "/"))
 		.finish())
 }
 
-#[post("/api_key/{id}/rotate")]
+#[post("/api_key/rotate")]
 async fn rotate(
 	browser_session: BrowserSessionSecret,
-	path: web::Path<IdPath>,
-	form: web::Form<CreateForm>,
+	form: web::Form<KeyForm>,
 	db: web::Data<Database>,
 ) -> Response {
-	let old = ApiKeySecret::try_from_string(path.id.clone(), db.get_ref()).await?;
-	if old.user() != browser_session.user() {
-		return Err(AppErrorKind::Unauthorized.into());
-	}
-	let remaining = if old.expires_at() == chrono::NaiveDateTime::MAX {
-		chrono::Duration::seconds(0)
-	} else {
-		old.expires_at() - Utc::now().naive_utc()
-	};
-	let new_key = ApiKeySecret::new_with_expiration(
-		browser_session.user().clone(),
-		form.service.clone(),
-		remaining,
-		db.get_ref(),
-	)
-	.await?;
-	old.delete(db.get_ref()).await?;
+	let new_key =
+		ApiKeySecret::rotate_with_user(form.key.clone(), browser_session.user(), db.get_ref())
+			.await?;
 	let mut data = BTreeMap::new();
 	data.insert("key", new_key.code().to_str_that_i_wont_print().to_string());
-	data.insert("id", new_key.code().to_str_that_i_wont_print().to_string());
 	let page = get_partial::<()>("api_key", data, None)?;
 	Ok(HttpResponse::Ok()
 		.content_type(ContentType::html())

--- a/src/handle_index.rs
+++ b/src/handle_index.rs
@@ -29,6 +29,10 @@ async fn index(browser_session: BrowserSessionSecret, db: web::Data<Database>) -
 	let mut index_data = BTreeMap::new();
 	index_data.insert("email", browser_session.user().email.clone());
 	let realmed_services = config.services.from_user(&browser_session.user());
+	let auth_email_header = config.auth_url_email_header.clone();
+	let auth_user_header = config.auth_url_user_header.clone();
+	let auth_name_header = config.auth_url_name_header.clone();
+	let auth_realms_header = config.auth_url_realms_header.clone();
 	drop(config);
 
 	let mut services_with_keys = Vec::new();
@@ -45,19 +49,19 @@ async fn index(browser_session: BrowserSessionSecret, db: web::Data<Database>) -
 	// Respond with the index page and set the X-Remote headers as configured
 	Ok(HttpResponse::Ok()
 		.append_header((
-			config.auth_url_email_header.as_str(),
+			auth_email_header.as_str(),
 			browser_session.user().email.clone(),
 		))
 		.append_header((
-			config.auth_url_user_header.as_str(),
+			auth_user_header.as_str(),
 			browser_session.user().username.clone(),
 		))
 		.append_header((
-			config.auth_url_name_header.as_str(),
+			auth_name_header.as_str(),
 			browser_session.user().name.clone(),
 		))
 		.append_header((
-			config.auth_url_realms_header.as_str(),
+			auth_realms_header.as_str(),
 			browser_session.user().realms.join(","),
 		))
 		.content_type(ContentType::html())

--- a/src/handle_index.rs
+++ b/src/handle_index.rs
@@ -5,23 +5,42 @@
 use std::collections::BTreeMap;
 
 use actix_web::http::header::ContentType;
-use actix_web::{get, HttpResponse};
+use actix_web::{get, web, HttpResponse};
+use serde::Serialize;
 
+use crate::database::Database;
 use crate::error::Response;
-use crate::secret::BrowserSessionSecret;
+use crate::secret::{ApiKeyInfo, ApiKeySecret, BrowserSessionSecret};
+use crate::service::Service;
 use crate::utils::get_partial;
 use crate::CONFIG;
 
+#[derive(Serialize)]
+struct ServiceWithKeys {
+	#[serde(flatten)]
+	service: Service,
+	api_keys: Vec<ApiKeyInfo>,
+}
+
 #[get("/")]
-async fn index(
-	browser_session: BrowserSessionSecret,
-) -> Response {
+async fn index(browser_session: BrowserSessionSecret, db: web::Data<Database>) -> Response {
 	// Render the index page
 	let config = CONFIG.read().await;
 	let mut index_data = BTreeMap::new();
 	index_data.insert("email", browser_session.user().email.clone());
 	let realmed_services = config.services.from_user(&browser_session.user());
-	let index_page = get_partial("index", index_data, Some(realmed_services))?;
+	drop(config);
+
+	let mut services_with_keys = Vec::new();
+	for svc in realmed_services.0 {
+		let keys = ApiKeySecret::list(browser_session.user(), &svc.name, db.get_ref()).await?;
+		services_with_keys.push(ServiceWithKeys {
+			service: svc,
+			api_keys: keys,
+		});
+	}
+
+	let index_page = get_partial("index", index_data, Some(services_with_keys))?;
 
 	// Respond with the index page and set the X-Remote headers as configured
 	Ok(HttpResponse::Ok()
@@ -69,7 +88,7 @@ mod tests {
 			App::new()
 				.app_data(web::Data::new(db.clone()))
 				.service(index)
-				.service(handle_magic_link::magic_link)
+				.service(handle_magic_link::magic_link),
 		)
 		.await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,17 +70,18 @@ pub mod database;
 pub mod error;
 pub mod oidc;
 pub mod saml;
+pub mod secret;
 pub mod service;
 pub mod user;
-pub mod secret;
 pub mod utils;
 pub mod webauthn;
 
+pub mod handle_api_key;
 pub mod handle_index;
-pub mod handle_login_post;
-pub mod handle_magic_link;
 pub mod handle_login;
+pub mod handle_login_post;
 pub mod handle_logout;
+pub mod handle_magic_link;
 pub mod handle_static;
 
 #[cfg(test)]

--- a/src/secret/api_key.rs
+++ b/src/secret/api_key.rs
@@ -1,0 +1,199 @@
+use chrono::{Duration, NaiveDateTime, Utc};
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppErrorKind, Result};
+use crate::user::User;
+use crate::{CONFIG, PROXY_ORIGIN_HEADER};
+
+use super::primitive::{InternalUserSecret, UserSecret, UserSecretKind};
+use super::{MetadataKind, SecretString};
+use crate::database::{Database, UserSecretRow};
+
+/// Metadata attached to an API key, storing the service name it grants access to.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiKeyMetadata {
+	pub service: String,
+}
+
+impl MetadataKind for ApiKeyMetadata {
+	async fn validate(&self, _: &Database) -> Result<()> {
+		let config = CONFIG.read().await;
+		if config.services.get(&self.service).is_none() {
+			return Err(AppErrorKind::NotFound.into());
+		}
+		Ok(())
+	}
+}
+
+/// Secret kind used for API keys.
+#[derive(PartialEq, Serialize, Deserialize)]
+pub struct ApiKeySecretKind;
+
+impl UserSecretKind for ApiKeySecretKind {
+	const PREFIX: &'static str = "api";
+	type Metadata = ApiKeyMetadata;
+
+	async fn duration() -> chrono::Duration {
+		CONFIG.read().await.api_key_max_expiration
+	}
+}
+
+/// API key secret type.
+pub type ApiKeySecret = UserSecret<ApiKeySecretKind>;
+
+impl ApiKeySecret {
+	/// Create a new API key with a custom expiration.
+	pub async fn new_with_expiration(
+		user: User,
+		service: String,
+		duration: Duration,
+		db: &Database,
+	) -> Result<Self> {
+		let max = ApiKeySecretKind::duration().await;
+		let final_duration = if max.num_seconds() == 0 || duration <= max {
+			duration
+		} else {
+			max
+		};
+		let expires_at = if final_duration.num_seconds() == 0 {
+			NaiveDateTime::MAX
+		} else {
+			Utc::now()
+				.naive_utc()
+				.checked_add_signed(final_duration)
+				.ok_or(AppErrorKind::InvalidDuration)?
+		};
+		let internal = InternalUserSecret {
+			code: SecretString::new(ApiKeySecretKind::PREFIX),
+			user,
+			expires_at,
+			metadata: ApiKeyMetadata { service },
+		};
+		internal.save(db).await?;
+		Ok(Self(internal))
+	}
+
+	/// List API keys for a user and service.
+	pub async fn list(user: &User, service: &str, db: &Database) -> Result<Vec<ApiKeyInfo>> {
+		let user_str = serde_json::to_string(user)?;
+		let rows = sqlx::query_as::<_, UserSecretRow>(
+"SELECT id, secret_type, user_data, expires_at, metadata, created_at FROM user_secrets WHERE secret_type = ? AND user_data = ?",
+)
+.bind(ApiKeySecretKind::PREFIX)
+.bind(user_str)
+.fetch_all(db)
+.await?;
+
+		let mut keys = Vec::new();
+		for row in rows {
+			let meta: ApiKeyMetadata = serde_json::from_str(&row.metadata)?;
+			if meta.service != service {
+				continue;
+			}
+			let display = format!("{}…", &row.id[..row.id.len().min(8)]);
+			let expires_at = if row.expires_at == NaiveDateTime::MAX {
+				None
+			} else {
+				Some(row.expires_at)
+			};
+			keys.push(ApiKeyInfo {
+				id: row.id,
+				display,
+				expires_at,
+			});
+		}
+		Ok(keys)
+	}
+
+	/// Get the associated service name.
+	pub fn service(&self) -> &str {
+		&self.0.metadata.service
+	}
+}
+
+/// Public representation of an API key for listing purposes.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiKeyInfo {
+	pub id: String,
+	pub display: String,
+	pub expires_at: Option<NaiveDateTime>,
+}
+
+impl actix_web::FromRequest for ApiKeySecret {
+	type Error = crate::error::Error;
+	type Future = BoxFuture<'static, Result<Self>>;
+
+	fn from_request(req: &actix_web::HttpRequest, _: &mut actix_web::dev::Payload) -> Self::Future {
+		let Some(key_header) = req.headers().get("X-Api-Key").cloned() else {
+			return Box::pin(async { Err(AppErrorKind::NotLoggedIn.into()) });
+		};
+		let Some(origin_header) = req.headers().get(PROXY_ORIGIN_HEADER).cloned() else {
+			return Box::pin(async { Err(AppErrorKind::MissingOriginHeader.into()) });
+		};
+		let Some(db) = req.app_data::<actix_web::web::Data<Database>>().cloned() else {
+			return Box::pin(async { Err(AppErrorKind::DatabaseInstanceError.into()) });
+		};
+		Box::pin(async move {
+			let key = key_header.to_str()?.to_string();
+			let origin_url = url::Url::parse(origin_header.to_str()?)?;
+			let config = CONFIG.read().await;
+			let service = config
+				.services
+				.from_auth_url_origin(&origin_url.origin())
+				.ok_or(AppErrorKind::InvalidOriginHeader)?;
+			let secret = ApiKeySecret::try_from_string(key, db.get_ref()).await?;
+			if secret.service() != service.name {
+				return Err(AppErrorKind::Unauthorized.into());
+			}
+			if !service.is_user_allowed(secret.user()) {
+				return Err(AppErrorKind::Unauthorized.into());
+			}
+			Ok(secret)
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::utils::tests::*;
+
+	#[tokio::test]
+	async fn test_api_key_crud() {
+		let db = db_connect().await;
+		let user = get_valid_user().await;
+		let key = ApiKeySecret::new_with_expiration(
+			user.clone(),
+			"example".to_string(),
+			Duration::try_seconds(60).unwrap(),
+			&db,
+		)
+		.await
+		.unwrap();
+		let id = key.code().to_str_that_i_wont_print().to_string();
+		let list = ApiKeySecret::list(&user, "example", &db).await.unwrap();
+		assert_eq!(list.len(), 1);
+		let fetched = ApiKeySecret::try_from_string(id.clone(), &db)
+			.await
+			.unwrap();
+		let new_key = ApiKeySecret::new_with_expiration(
+			user.clone(),
+			"example".to_string(),
+			Duration::try_seconds(60).unwrap(),
+			&db,
+		)
+		.await
+		.unwrap();
+		fetched.delete(&db).await.unwrap();
+		let new_id = new_key.code().to_str_that_i_wont_print().to_string();
+		let list = ApiKeySecret::list(&user, "example", &db).await.unwrap();
+		assert_eq!(list.len(), 1);
+		let fetched_new = ApiKeySecret::try_from_string(new_id.clone(), &db)
+			.await
+			.unwrap();
+		fetched_new.delete(&db).await.unwrap();
+		let list = ApiKeySecret::list(&user, "example", &db).await.unwrap();
+		assert!(list.is_empty());
+	}
+}

--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -1,28 +1,30 @@
 #![allow(async_fn_in_trait)]
-pub mod primitive;
+pub mod cleanup;
 pub mod ephemeral_primitive;
 pub mod metadata;
-pub mod cleanup;
+pub mod primitive;
 
 // Secret types
+pub mod api_key;
 pub mod browser_session;
 pub mod login_link;
+pub mod oidc_authcode;
+pub mod oidc_token;
 pub mod proxy_code;
 pub mod proxy_session;
-pub mod oidc_token;
-pub mod oidc_authcode;
 pub mod webauthn_auth;
 pub mod webauthn_reg;
 
+pub use api_key::{ApiKeyInfo, ApiKeySecret};
 pub use browser_session::BrowserSessionSecret;
 pub use login_link::LoginLinkSecret;
-pub use proxy_code::ProxyCodeSecret;
-pub use proxy_session::ProxySessionSecret;
+pub use metadata::{ChildSecretMetadata, EmptyMetadata, MetadataKind};
 pub use oidc_authcode::OIDCAuthCodeSecret;
 pub use oidc_token::OIDCTokenSecret;
+pub use proxy_code::ProxyCodeSecret;
+pub use proxy_session::ProxySessionSecret;
 pub use webauthn_auth::WebAuthnAuthSecret;
 pub use webauthn_reg::WebAuthnRegSecret;
-pub use metadata::{MetadataKind, ChildSecretMetadata, EmptyMetadata};
 
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +38,9 @@ pub fn get_prefix(prefix: &str) -> String {
 pub struct SecretString(String);
 
 impl SecretString {
-	pub fn to_str_that_i_wont_print(&self) -> &str { &self.0 }
+	pub fn to_str_that_i_wont_print(&self) -> &str {
+		&self.0
+	}
 }
 
 impl SecretString {

--- a/static/templates/api_key.html.hbs
+++ b/static/templates/api_key.html.hbs
@@ -1,0 +1,9 @@
+{{> header }}
+<div class="relative p-4 w-full max-w-md h-full md:h-auto">
+        <div class="relative p-4 text-center bg-white rounded-lg shadow-sm dark:bg-gray-800 sm:p-5">
+                <p class="mb-4 text-md text-gray-900 dark:text-white">Store this API key now. You won't be able to see it again.</p>
+                <code id="api-key" class="block p-2 bg-gray-100 dark:bg-gray-700 break-words">{{data.key}}</code>
+                <a href="/" class="py-2 px-3 m-2 text-sm font-medium text-center text-white rounded-lg bg-primary-800 hover:bg-primary-700 focus:ring-4 focus:outline-hidden focus:ring-primary-300 dark:focus:ring-primary-900">Back</a>
+        </div>
+</div>
+{{> footer }}

--- a/static/templates/api_key.html.hbs
+++ b/static/templates/api_key.html.hbs
@@ -1,9 +1,9 @@
 {{> header }}
 <div class="relative p-4 w-full max-w-md h-full md:h-auto">
-        <div class="relative p-4 text-center bg-white rounded-lg shadow-sm dark:bg-gray-800 sm:p-5">
-                <p class="mb-4 text-md text-gray-900 dark:text-white">Store this API key now. You won't be able to see it again.</p>
-                <code id="api-key" class="block p-2 bg-gray-100 dark:bg-gray-700 break-words">{{data.key}}</code>
-                <a href="/" class="py-2 px-3 m-2 text-sm font-medium text-center text-white rounded-lg bg-primary-800 hover:bg-primary-700 focus:ring-4 focus:outline-hidden focus:ring-primary-300 dark:focus:ring-primary-900">Back</a>
-        </div>
+	<div class="relative p-4 text-center bg-white rounded-lg shadow-sm dark:bg-gray-800 sm:p-5">
+		<p class="mb-4 text-md text-gray-900 dark:text-white">Store this API key now. You won't be able to see it again.</p>
+		<code id="api-key" class="block p-2 bg-gray-100 dark:bg-gray-700 break-words">{{data.key}}</code>
+		<a href="/" class="py-2 px-3 m-2 text-sm font-medium text-center text-white rounded-lg bg-primary-800 hover:bg-primary-700 focus:ring-4 focus:outline-hidden focus:ring-primary-300 dark:focus:ring-primary-900">Back</a>
+	</div>
 </div>
 {{> footer }}

--- a/static/templates/index.html.hbs
+++ b/static/templates/index.html.hbs
@@ -39,13 +39,39 @@
 						<div class="font-normal text-gray-500">realm</div>
 					</div>
 				</th>
-				<td class="p-6 py-4">
-					<div class="flex-shrink-0 w-6 h-6"></div>
-				</td>
-			</tr>
-			{{/each}}
-		</tbody>
-	</table>
+                                <td class="p-6 py-4">
+                                        <div class="flex-shrink-0 w-6 h-6"></div>
+                                </td>
+                        </tr>
+                        <tr class="border-b dark:border-gray-700 border-gray-200">
+                                <td colspan="2" class="px-6 py-4">
+                                        <details>
+                                                <summary>API Keys</summary>
+                                                <ul>
+{{#each api_keys}}
+<li class="my-2">
+{{this.display}} - {{#if this.expires_at}}{{this.expires_at}}{{else}}never{{/if}}
+<form method="post" action="/api_key/{{this.id}}/rotate" class="inline">
+<input type="hidden" name="service" value="{{../name}}" />
+<button class="text-sm">Rotate</button>
+</form>
+<form method="post" action="/api_key/{{this.id}}/delete" class="inline">
+<button class="text-sm">Delete</button>
+</form>
+</li>
+{{/each}}
+                                                </ul>
+                                                <form method="post" action="/api_key" class="mt-4">
+                                                        <input type="hidden" name="service" value="{{name}}" />
+                                                        <input type="number" name="expiration" placeholder="secs" class="border" />
+                                                        <button type="submit" class="text-sm">Create</button>
+                                                </form>
+                                        </details>
+                                </td>
+                        </tr>
+                        {{/each}}
+                </tbody>
+        </table>
 </div>
 
 {{> script name="webauthn" }}

--- a/static/templates/index.html.hbs
+++ b/static/templates/index.html.hbs
@@ -51,11 +51,12 @@
 {{#each api_keys}}
 <li class="my-2">
 {{this.display}} - {{#if this.expires_at}}{{this.expires_at}}{{else}}never{{/if}}
-<form method="post" action="/api_key/{{this.id}}/rotate" class="inline">
-<input type="hidden" name="service" value="{{../name}}" />
+<form method="post" action="/api_key/rotate" class="inline">
+<input type="hidden" name="key" value="{{this.key}}" />
 <button class="text-sm">Rotate</button>
 </form>
-<form method="post" action="/api_key/{{this.id}}/delete" class="inline">
+<form method="post" action="/api_key/delete" class="inline">
+<input type="hidden" name="key" value="{{this.key}}" />
 <button class="text-sm">Delete</button>
 </form>
 </li>


### PR DESCRIPTION
## Summary
- manage API keys through the secrets module and bind them to services
- support API key auth via `X-Api-Key` header and index UI for rotate/delete
- cover API key flows with unit tests and hurl e2e scenario

## Testing
- `cargo build` *(failed: failed to get `actix-web` as a dependency of package `magicentry v0.6.6`)*
- `cargo clippy --all-features` *(failed: failed to get `actix-web` as a dependency of package `magicentry v0.6.6`)*
- `cargo test --features kube` *(failed: failed to get `actix-web` as a dependency of package `magicentry v0.6.6`)*
- `yarn build`
- `yarn test` *(failed: failed to get `actix-web` as a dependency of package `magicentry v0.6.6`)*

------
https://chatgpt.com/codex/tasks/task_b_68ae21bd4c1c83259ec5fe545f570e52